### PR TITLE
replace "subject" by "research participant"

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -13,7 +13,7 @@ behind many fields of brain sciences.  Despite possibly terabytes of
 neuroimaging data collected for research daily, just a small fraction
 becomes publicly available. Partially it is because management of
 neuroimaging data requires to confirm to established legal norms,
-i.e. addressing the aspect of subjects privacy.  Those norms are
+i.e. addressing the aspect of research participants privacy.  Those norms are
 usually established by institutional review boards (IRB, or otherwise
 called ethics committees), which are in turn "governed" by the federal
 regulations, such as `45 Code of Federal Regulations Part 46
@@ -25,7 +25,7 @@ the past century, decentralization of those committees, and lack of a
 neuroimaging studies there is no commonly accepted version of a
 Consent form template which would allow for collected imaging data to
 be shared as openly as possible while providing adequate guarantees
-for subjects' privacy**.  In majority of the cases, used Consent forms
+for research participants' privacy**.  In majority of the cases, used Consent forms
 simply do not include **any** provision for public sharing of the data
 to get a "speedy" IRB approval for a study.  Situation is particularly
 tricky because major granting agencies (e.g. NIH, NSF) nowadays
@@ -36,7 +36,7 @@ Overall approach
 ================
 
 We would like to facilitate neuroimaging data sharing by providing an "out of
-the box" solution addressing aforementioned human subjects concerns and
+the box" solution addressing aforementioned human research participants concerns and
 consisting of
 
 - widely acceptable consent form allowing deposition of anonymized data

--- a/docs/source/anon_tools.rst
+++ b/docs/source/anon_tools.rst
@@ -9,11 +9,11 @@ Sanitization of headers/filenames
 - see
   http://www.researchgate.net/post/Best_free_tool_for_DICOM_data_anonymization
   discussion on sanitization of DICOM headers
-- `DeID <http://www.nitrc.org/projects/deid>`_ (`see paper 
+- `DeID <http://www.nitrc.org/projects/deid>`_ (`see paper
   <http://journal.frontiersin.org/article/10.3389/fnins.2015.00325/full>`_),
   which provides an interactive tool for inspection and sanitization
   of Analyze and NIfTI images
-- `PyDICOM's deid <https://pydicom.github.io/deid/>`_, the "best effort 
+- `PyDICOM's deid <https://pydicom.github.io/deid/>`_, the "best effort
   anonymization for medical images using python" assists in filtering out
   DICOM fields and also masking out actual image data
 
@@ -31,7 +31,7 @@ One of the approaches is perform complete skull stripping, e.g. using
 - `3dSkullStrip
   <http://afni.nimh.nih.gov/pub/dist/doc/program_help/3dSkullStrip.html>`_
   of `AFNI <http://afni.nimh.nih.gov/>`_
--  `FreeSurfer <https://surfer.nmr.mgh.harvard.edu/>`_ 
+-  `FreeSurfer <https://surfer.nmr.mgh.harvard.edu/>`_
 
 Some dedicated anonymization tools work on this principle, e.g. `DeID`_
 
@@ -40,8 +40,8 @@ Faces/dental stripping
 
 More "gentle" approach is to strip out only the areas of face/mouth
 leaving skull, which might be important for some types of analysis.
-Usually achieved through alignment of pre-crafted mask to the subject
-anatomy and removing of the masked out regions.
+Usually achieved through alignment of pre-crafted mask to the research
+participants anatomy and removing of the masked out regions.
 
 - `BIDSonym <https://github.com/PeerHerholz/BIDSonym>`_ - a BIDS app interfacing a
   number of methods (`pydeface`_, `quickshear`_, `mri_deface`_) listed below
@@ -64,4 +64,3 @@ facial features in the anatomical images:
 
 - `Obscuring Surface Anatomy in Volumetric Imaging Data <http://link.springer.com/article/10.1007%2Fs12021-012-9160-3>`_
   Used for HCP data
-

--- a/docs/source/contribute.rst
+++ b/docs/source/contribute.rst
@@ -36,7 +36,7 @@ We would welcome your feedback  very much, in particular
 
 - what concerns on public sharing of neuroimaging data you might have
   if any identifiable information removed (e.g. skull stripped) and
-  subjects agreed to those terms?
+  research participants agreed to those terms?
 
 - what particular consent form composition and wording aspects would
   you recommend? (e.g. "make it an explicit additional form requiring


### PR DESCRIPTION
Referring to the human participants in our studies as "subjects" is derogative and does not reflect the important (and usually voluntary) contributions of these human participants in advancing science in our field.

Consider this: if your parents would voluntarily contribute to your research, would you think of them as "subjects"?