### PR TITLE
Finnish translation

### DIFF
--- a/docs/source/gdpr/data_user_agreement.rst
+++ b/docs/source/gdpr/data_user_agreement.rst
@@ -52,6 +52,7 @@ Translations
    i18n/data_user_agreement.de.rst
    i18n/data_user_agreement.el.rst
    i18n/data_user_agreement.es.rst
+   i18n/data_user_agreement.fi.rst
    i18n/data_user_agreement.fr.rst
    i18n/data_user_agreement.it.rst
    i18n/data_user_agreement.nl.rst

--- a/docs/source/gdpr/i18n/data_user_agreement.fi.rst
+++ b/docs/source/gdpr/i18n/data_user_agreement.fi.rst
@@ -7,7 +7,7 @@ Finnish
 Tunnistettavien tietojen käyttäjän käyttöoikeussopimus
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-**Versio:** OBC-GDPR-DUA.fi 1.0.0
+**Versio:** OBC-GDPR-DUA.fi 1.1.0
 
 Pyydän käyttöoikeutta <OSASTON> digitaaliseen tietovarantoon tallennettuihin tietoihin. <OSASTO> on osa <TUTKIMUSLAITOSTA>, jonka kotipaikka on <KAUPUNKI>, <MAA> (jäljempänä <TUTKIMUSLAITOKSEN LYHYT NIMI>).
 

--- a/docs/source/gdpr/i18n/data_user_agreement.fi.rst
+++ b/docs/source/gdpr/i18n/data_user_agreement.fi.rst
@@ -1,0 +1,21 @@
+.. _chap_dua_fi:
+
+Finnish
+-------
+(translation courtesy of Marko Havu)
+
+Tunnistettavien tietojen käyttäjän käyttöoikeussopimus
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+**Versio:** OBC-GDPR-DUA.fi 1.0.0
+
+Pyydän käyttöoikeutta <OSASTON> digitaaliseen tietovarantoon tallennettuihin tietoihin. <OSASTO> on osa <TUTKIMUSLAITOSTA>, jonka kotipaikka on <KAUPUNKI>, <MAA> (jäljempänä <TUTKIMUSLAITOKSEN LYHYT NIMI>).
+
+Hyväksymällä tämän sopimuksen minusta tulee GDPR:n mukainen `rekisterinpitäjä <https://ec.europa.eu/info/law/law-topic/data-protection/reform/rules-business-and-organisations/obligations/controller-processor/what-data-controller-or-data-processor_fi>`_ . Käyttööni saamani tiedot muodostavat henkilötietorekisterin, ja olen velvollinen käsittelemään niitä seuraavien ehtojen mukaisesti:
+
+1. Noudatan tietojen käsittelyssä paikallisia säädöksiä ja tutkimuslaitoksessani vallitsevia sääntöjä ja määräyksiä. Tämä sopimus ei kumoa voimassa olevia tietosuojasäädöksiä.
+2. En yritä selvittää tutkimukseen osallistuneiden henkilöllisyyttä. En yhdistä tietoja muihin tietoihin siten, että henkilöllisyys on selvitettävissä. En hanki pseudonymisointiavainta, jonka avulla nämä tiedot pystytään yhdistämään henkilöön, enkä ota vastaan yksittäistä tutkittavaa koskevia lisätietoja.
+3. En julkaise näitä tietoja tai jaa niitä kenellekään, jolle ei ole myönnetty niihin käyttöoikeutta. Jokaisen käyttäjän on haettava käyttöoikeutta erikseen ja allekirjoitettava tämä käyttöoikeussopimus. Tämä koskee myös tutkimusyhteisöni jäseniä.
+4. [VALINNAINEN] Jaan toissijaisia tietoja tai johdannaistietoja (esimerkiksi tilastokarttoja tai mallineita) ainoastaan siinä tapauksessa, että tiedot koskevat ryhmätasoa, eikä niistä voi selvittää yksittäistä tutkittavaa koskevia tietoja.
+5. Viittaan tietojen lähteeseen, kun esitän tuloksia tai algoritmeja, jotka ovat syntyneet näitä tietoja käyttämällä: (a) Julkaisuissa, kirjan kappaleissa, kirjoissa, postereissa, suullisissa esityksissä ja muissa esityksissä, joissa esitellään näistä tiedoista syntyneitä tuloksia, tietojen lähde esitetään seuraavasti: "Tiedot toimitti (osittain) <tutkimuskeskus/yliopiston laitos>, <yliopisto>, <maa>". (b) Näitä tietoja käyttävien julkaisujen tai esitysten tekijöiden tulee viitata asiaankuuluviin julkaisuihin, joissa kuvataan <tutkimuskeskuksessa/yliopiston laitoksella> tiedon keruuta ja käsittelyä varten kehitetyt ja käytetyt menetelmät. Se, mihin julkaisuihin on viitattava tietyssä tutkimuksessa, riippuu siitä, mitä tietoja käytettiin ja mihin tarkoitukseen. Julkaisuluettelo lisätään tarvittaessa kokoelmaan. (c) <Tutkimuskeskus/yliopiston laitos> tai <yliopisto> tai tutkijat, joilta tiedot ovat peräisin, eivät vastaa niistä saaduista tuloksista tai johdannaistiedoista. Heitä ei tule lisätä julkaisujen tai esitysten tekijäluetteloon ilman heidän suostumustaan.
+6. Näiden ehtojen noudattamatta jättämisen seurauksena menetän käyttöoikeuteni tietoihin.

--- a/docs/source/gdpr/i18n/ultimate_gdpr.fi.rst
+++ b/docs/source/gdpr/i18n/ultimate_gdpr.fi.rst
@@ -4,11 +4,7 @@ Finnish
 -------
 (translation courtesy of Marko Havu)
 
-**Versio:** OBC-GDPR-ULT.fi 1.0.0
-
-Ohjeet
-~~~~~~
-Alla on yleiskäyttöisen (GDPR-yhteensopivan) suostumuslomakkeen viimeisin versio. Lomakkeessa käytetään GDPR:n mukaisia sanamuotoja, kun viitataan yksityisyyden suojaan ja siihen, miten tutkittavien tietoja aiotaan käsitellä ja jakaa. Niinpä lomaketta voidaan pitää tietosuojailmoituksena. Tietoon perustuva suostumus pyydetään edelleen varsinaisella suostumuslomakkeella. Osa lomakkeen virkkeistä on hakasulkeissa ``[]`` sen merkiksi, että ne voidaan poistaa tai korvata sen mukaan, mitä paikallinen lainsäädäntö tai eettinen lautakunta asiasta määräävät. Osa virkkeistä sisältää täytettäviä kenttiä. Ne on merkitty kulmasulkein ``<>``.
+**Versio:** OBC-GDPR-ULT.fi 1.1.0
 
 Tietojen käsittely ja tallennus
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/gdpr/i18n/ultimate_gdpr.fi.rst
+++ b/docs/source/gdpr/i18n/ultimate_gdpr.fi.rst
@@ -1,0 +1,46 @@
+.. _chap_consent_ultimate_gdpr_fi:
+
+Finnish
+-------
+(translation courtesy of Marko Havu)
+
+**Versio:** OBC-GDPR-ULT.fi 1.0.0
+
+Ohjeet
+~~~~~~
+Alla on yleiskäyttöisen (GDPR-yhteensopivan) suostumuslomakkeen viimeisin versio. Lomakkeessa käytetään GDPR:n mukaisia sanamuotoja, kun viitataan yksityisyyden suojaan ja siihen, miten tutkittavien tietoja aiotaan käsitellä ja jakaa. Niinpä lomaketta voidaan pitää tietosuojailmoituksena. Tietoon perustuva suostumus pyydetään edelleen varsinaisella suostumuslomakkeella. Osa lomakkeen virkkeistä on hakasulkeissa ``[]`` sen merkiksi, että ne voidaan poistaa tai korvata sen mukaan, mitä paikallinen lainsäädäntö tai eettinen lautakunta asiasta määräävät. Osa virkkeistä sisältää täytettäviä kenttiä. Ne on merkitty kulmasulkein ``<>``.
+
+Tietojen käsittely ja tallennus
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Tutkimuksessa, johon osallistut, kerätään, käytetään ja tallennetaan tietoja sinusta. Tämän lisäksi tietoja saatetaan käyttää tulevissa tutkimusprojekteissa kliinisen ja kognitiivisen neurotieteen alalla. Tiedot sisältävät aivokuvia ja mahdollisia muita kuvia sekä mahdollisesti tutkimuksessa kerättyjä testituloksia, perhettä ja terveydentilaa koskevia tietoja sekä muita henkilötietoja kuten sukupuolen ja iän.
+Suostumalla tutkittavaksi annat tutkimukselle maksutta arvokkaan lahjan, joka voi olla avuksi toisille. [Tutkimus, jossa on käytetty sinun tietojasi, voi mahdollisesti johtaa uusien aivotutkimusmenetelmien, diagnostisten testien, lääkkeiden tai muiden kaupallisten tuotteiden syntymiseen. Jos näin käy, ei sinulle ole varattu osuutta tällaisesta tuotteesta syntyvistä tuotoista, eikä sinulle synny omistusoikeutta tuotteisiin.] Pyydämme suostumustasi tietojesi käyttöön.
+
+Tietojen luottamuksellisuus
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Käsityksemme mukaan julkaisemamme tiedot eivät sisällä tietoja, joista sinut voisi kohtuullisesti käytettävissä olevin keinoin tunnistaa. Yksityisyytesi turvaamiseksi tietojen yksilöintiin käytetään tunnistekoodia, jotta ihmiset eivät tietäisi nimeäsi tai sitä, mitkä tiedot kuuluvat sinulle. Nimesi ja muut tiedot, joista sinut voisi suoraan tunnistaa, jätetään pois. [Aivokuvista poistetaan tunnistettavat kasvonpiirteet]. Tietojen yhdistäminen sinuun onnistuu ainoastaan henkilötietojen käsittelijöiden (eli tutkimuksen tekijöiden) käytössä olevan rekisterin avulla. Tätä rekisteriä säilytetään turvallisesti paikallisessa tutkimuslaitoksessa. Tietojasi ei voida yhdistää sinuun tutkimuksesta tehtävissä raporteissa ja julkaisuissa. Nimelläsi varustettujen lisätietojen (esimerkiksi potilaskertomukseesi liitettyjen aivokuvien) perusteella on kuitenkin mahdollista yhdistää tietokannassamme olevat kuvat tai muut tiedot sinuun. Riskiarviomme mukaan mahdollisuus päästä käsiksi näihin tietoihin palvelimillamme on kuitenkin pieni (katso yliopiston tai tutkimuslaitoksen tekemä vaikutusten arviointi osoitteessa <URL>).
+
+Tietoihin pääsy tarkistusta varten
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Joillakin henkilöillä on pääsy kaikkiin tietoihisi mukaan lukien alkuperäiset tiedot, joissa on nimesi. Tämä on tarpeen, jotta voidaan tarkistaa, että tutkimus tehdään hyvällä ja luotettavalla tavalla ja jotta sinulle ja lääkärillesi pystytään ilmoittamaan mahdollisista yllätyslöydöksistä aivokuvissasi. Seuraavilla henkilöillä on tarkistusta varten pääsy tietoihisi: tutkimuksen turvallisuudesta vastaava paikallinen toimikunta, tutkimuksen vastuulliselle tutkijalle työskentelevä <tutkimuslaitoksen> rekisterinpitäjä sekä paikalliset, kansalliset ja kansainväliset valvontaviranomaiset. He käsittelevät tietojasi luottamuksellisesti.
+
+Tietojen säilytysaika
+~~~~~~~~~~~~~~~~~~~~~
+Tietoja ei ole suunniteltu hävitettävän, koska niitä voidaan käyttää uudelleen tutkimustarkoituksessa. Arvioimme kuitenkin aina <aika vuosina> vuoden välein uudelleen, kannattaako tietoja yhä säilyttää.
+
+Suostumuksen peruminen
+~~~~~~~~~~~~~~~~~~~~~~
+Voit perua suostumuksesi henkilötietojesi käyttöön milloin tahansa. Tämä koskee sekä tätä tutkimusta että jakamista tulevien tutkimusprojektien käyttöön. Huomaa kuitenkin, että kun tietosi on kopioitu toisen tutkimuslaitoksen käyttöön, kopion poistaminen on mahdotonta.
+
+Siirto Euroopan Unionin (EU) ulkopuolelle
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Koodatut tietosi voidaan lähettää tai niihin voidaan antaa pääsy myös EU:n ulkopuolelle. Tämä on tarpeen, jotta muualla kuin EU:ssa sijaitsevat tutkijat voisivat tarkastaa tutkimuksen tulokset. Lisäksi tietoja saatetaan käyttää tulevissa tutkimusprojekteissa kliinisen ja kognitiivisen neurotieteen alalla. Henkilötietojasi suojaavat EU-säännöt eivät päde EU:n ulkopuolisissa maissa. Henkilötietosi on kuitenkin suojattu saman tasoisesti :ref:`tietojen käyttäjän käyttöoikeussopimuksen<chap_dua_fi>` nojalla.
+
+Lisätietoja oikeuksistasi tietojen käsittelyyn liittyen
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Lisätietoja oikeuksistasi tietojen käsittelyyn liittyen on saatavilla <valvontaviranomaisen> verkkosivustossa. Jos sinulla on kysyttävää oikeuksistasi, ota yhteys henkilötietojesi käsittelystä vastaavaan henkilöön. Tässä tutkimuksessa henkilötietojesi käsittelystä vastaa <käsittelijä> (yhteystiedot liitteessä).
+
+Jos sinulla on kysyttävää tai huomautettavaa henkilötietojesi käsittelyyn liittyen, neuvomme olemaan ensimmäiseksi yhteydessä tutkimuspaikkaan. Voit ottaa yhteyttä myös <tutkimuslaitoksen> tietosuojavastaavaan (yhteystiedot liitteessä) tai <valvontaviranomaiseen>.
+
+- Päivämäärä:
+- Vastaanottaja:
+- Allekirjoitus:

--- a/docs/source/gdpr/ultimate_gdpr.rst
+++ b/docs/source/gdpr/ultimate_gdpr.rst
@@ -68,6 +68,7 @@ Translations
    i18n/ultimate_gdpr.de.rst
    i18n/ultimate_gdpr.el.rst
    i18n/ultimate_gdpr.es.rst
+   i18n/ultimate_gdpr.fi.rst
    i18n/ultimate_gdpr.fr.rst
    i18n/ultimate_gdpr.it.rst
    i18n/ultimate_gdpr.nl.rst


### PR DESCRIPTION
This PR adds a Finnish translation to the GDPR edition. BTW, there is a small discrepancy in what is included in the localised versions of OBC-GDPR-ULT and OBC-GDPR-DUA: the localised versions of OBC-GDPR-ULT seem to include the *Instructions* chapter (albeit without the chapter heading), whereas the localised versions of OBC-GDPR-DUA do not include the *General considerations for a Data User Agreement* chapter or the introductory text.

*General considerations for a Data User Agreement* was included in the Google Docs translation package, so I have translated it, but did not include it in the PR, since it was omitted from other language versions. I'll add it here, in case it was meant to be included:
```rst
Yleisiä huomioita tietojen käyttäjän käyttöoikeussopimuksesta
--------------------------------------------------------------

Biolääketieteelliset tiedot ovat EU:n tietosuoja-asetuksen (GDPR) mukaan henkilötietoja. Tämän käyttöoikeussopimuksen on tarkoitus olla niin rajoittava, että se soveltuu biolääketieteellisten tietojen julkiseen jakamiseen. Jos tietojen jakaminen liittyy meneillään olevaan yhteistyöhön, suosittelemme sallivampaa sopimusta.

- Sopimuksen on soveltuvin osin määrättävä, miten tutkittavien yksityisyyden suojasta pidetään huolta.
- Toissijaisten tietojen ja johdannaistietojen uudelleenjakamista käsittelevä kohta 4 on kiistanalainen. Sen sisällyttämisen tai pois jättämisen tulee perustua huolelliseen harkintaan.
- Kohtaan 4 liittyen voidaan määrätä, miten tietojen alkuperäinen lähde ilmoitetaan julkaisuissa. Voit esimerkiksi määrätä, haluatko tulla mainituksi, jos joku käyttää mallinetta, jonka jokin kolmas osapuoli (tutkija tai tutkimusryhmä) on luonut julkaisemiesi tietojen pohjalta.
```