### PR TITLE
RF: Switch to lualatex for PDF - supports unicode

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -205,6 +205,10 @@ latex_documents = [
    authors, 'manual'),
 ]
 
+# ones with unicode support
+# latex_engine = "xelatex"
+latex_engine = "lualatex"
+
 # The name of an image file (relative to this directory) to place at the top of
 # the title page.
 #latex_logo = None


### PR DESCRIPTION
Build still fails partially -- there is no support for .svg files
inclusion and those are using in README IIRC.  Also chinese does not
render BUT it does produce PDF

- xelatex failed for me in more ways and no .pdf was generated.

@con ppl -- please contribute

Closes gh-39

TODO
- [ ] resolve build failures (.svg files)
- [ ] make sure that chinese renders
- [ ] Add instructions on installation of lualatex for PDF: `sudo apt-get install texlive-luatex` on debian systems
- [ ] Enable PDF building in RTD and see if does it correctly