### PR TITLE
Unicorns! (add non-GH-based contributors to .all-contributorsrc)

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -170,6 +170,160 @@
       "contributions": [
         "design"
       ]
+    },
+    {
+      "name": " Nicolas Pascual Leone Espinosa",
+      "avatar_url": "https://unicornify.pictures/avatar/50816018529642639627559528262906053204?s=128",
+      "contributions": [
+        "translation"
+      ]
+    },
+    {
+      "name": "Karolina Finc",
+      "avatar_url": "https://unicornify.pictures/avatar/3286594976052355665756813966559391795?s=128",
+      "contributions": [
+        "translation"
+      ]
+    },
+    {
+      "name": "Dr. Kyrre E. Emblem",
+      "avatar_url": "https://unicornify.pictures/avatar/129191881538174400234909343737821206176?s=128",
+      "contributions": [
+        "translation"
+      ]
+    },
+    {
+      "name": "Saurabh Chavan",
+      "avatar_url": "https://unicornify.pictures/avatar/4691228916091123621709038074142801892?s=128",
+      "contributions": [
+        "translation"
+      ]
+    },
+    {
+      "name": "Dr Radim Jančálek",
+      "avatar_url": "https://unicornify.pictures/avatar/201254758934706648287772069158647925952?s=128",
+      "contributions": [
+        "translation"
+      ]
+    },
+    {
+      "name": "Hardik Kothare ",
+      "avatar_url": "https://unicornify.pictures/avatar/227744230451921531094269175890707961174?s=128",
+      "contributions": [
+        "translation"
+      ]
+    },
+    {
+      "name": "Valentina Borghesani ",
+      "avatar_url": "https://unicornify.pictures/avatar/115564128361764407310819661237289578203?s=128",
+      "contributions": [
+        "translation"
+      ]
+    },
+    {
+      "name": "Dr Francesca Pizzini",
+      "avatar_url": "https://unicornify.pictures/avatar/331779447641493845804226957467132862211?s=128",
+      "contributions": [
+        "translation"
+      ]
+    },
+    {
+      "name": "Clara Moreau",
+      "avatar_url": "https://unicornify.pictures/avatar/168303728220231581562694179710521562469?s=128",
+      "contributions": [
+        "translation"
+      ]
+    },
+    {
+      "name": "Dr Amira Serifovic Trbalic",
+      "avatar_url": "https://unicornify.pictures/avatar/204357623244501477137334102859890418518?s=128",
+      "contributions": [
+        "translation"
+      ]
+    },
+    {
+      "name": "Sara Fernández",
+      "avatar_url": "https://unicornify.pictures/avatar/140890128984856104640333123676081178303?s=128",
+      "contributions": [
+        "translation"
+      ]
+    },
+    {
+      "name": "Dr Vera Keil",
+      "avatar_url": "https://unicornify.pictures/avatar/61700033103512558814640108900367250360?s=128",
+      "contributions": [
+        "translation"
+      ]
+    },
+    {
+      "name": "Dr Henk-Jan Mutsaerts",
+      "avatar_url": "https://unicornify.pictures/avatar/295591703619980376282459646695045405785?s=128",
+      "contributions": [
+        "translation"
+      ]
+    },
+    {
+      "name": "Anne Hespel ",
+      "avatar_url": "https://unicornify.pictures/avatar/317452050964486276281487666867339101373?s=128",
+      "contributions": [
+        "translation"
+      ]
+    },
+    {
+      "name": "Dr. Esin Öztürk Işık",
+      "avatar_url": "https://unicornify.pictures/avatar/252802718727300670504627158800121396591?s=128",
+      "contributions": [
+        "translation"
+      ]
+    },
+    {
+      "name": "Monika Boruta-Żywiczyńska",
+      "avatar_url": "https://unicornify.pictures/avatar/69522165094006649829964301479204649060?s=128",
+      "contributions": [
+        "translation"
+      ]
+    },
+    {
+      "name": "María de la Iglesia Vayá ",
+      "avatar_url": "https://unicornify.pictures/avatar/34643475542453809928725084302431092545?s=128",
+      "contributions": [
+        "translation"
+      ]
+    },
+    {
+      "name": "Dr Anne Hespel ",
+      "avatar_url": "https://unicornify.pictures/avatar/146034832033234963545725326912853601122?s=128",
+      "contributions": [
+        "translation"
+      ]
+    },
+    {
+      "name": "Dr Patricia Clement ",
+      "avatar_url": "https://unicornify.pictures/avatar/321287267194492895197491731370358741236?s=128",
+      "contributions": [
+        "translation"
+      ]
+    },
+    {
+      "name": "Dr Elise Bannier",
+      "avatar_url": "https://unicornify.pictures/avatar/79392824976212577294463559588700788209?s=128",
+      "contributions": [
+        "translation"
+      ]
+    },
+    {
+      "name": "Dr Maria de la Iglesia",
+      "avatar_url": "https://unicornify.pictures/avatar/151390569491455074342299757350879636412?s=128",
+      "contributions": [
+        "translation"
+      ]
+    },
+    {
+      "name": "Dr Vasileios K. Katsaros",
+      "avatar_url": "https://unicornify.pictures/avatar/312184497630168570921714213494253435042?s=128",
+      "contributions": [
+        "translation"
+      ]
     }
   ],
   "contributorsPerLine": 7,

--- a/.allcontrib_map.json
+++ b/.allcontrib_map.json
@@ -1,0 +1,16 @@
+{
+  "known_contributors" : [
+    {
+      "name": "Dorota Jarecka",
+      "login": "djarecka"
+    },
+    {
+      "name": "Matteo Visconti di Oleggio Castello",
+      "login": "mvdoc"
+    },
+    {
+      "name": "Camille Maumet",
+      "login": "cmaumet"
+    }
+  ]
+}

--- a/tools/nonghcontrib.py
+++ b/tools/nonghcontrib.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+
+"""
+Grep for "courtesy" in repository content and roughly extract all mentioned names.
+If they are not yet included in .all-contributorsrc, names are added with a unicorn
+identicon based on a numeric hash of their full name.
+
+USAGE:
+Run from the root of the repository:
+./tools/nonghcontrib.py
+"""
+
+import json
+import hashlib
+from pathlib import Path
+from subprocess import run, PIPE
+
+
+flatten = lambda l: [item for sublist in l for item in sublist]
+
+
+def get_ack():
+    """
+    grep for "courtesy" to find translation contributors in the root of a git
+    repository.
+
+    :param path: Str, Path to the root of a git repo
+    :return: result: set of str with contributor
+    """
+    cmd = ["git", "grep", "-i", "courtesy", "--", './*', ':!tools/*']
+    # get translators
+    log = run(cmd, stdout=PIPE).stdout.decode().split('\n')
+    # this a long list, we have to get creative to split it correctly.
+    # First: get rid of 'of' and stray ')' before or after names
+    names_rough = [l.split('of ')[-1].strip(')').split(', ') for l in log]
+    # there sometimes are 'and' or '&'
+    better = [[n.split('&') for n in nr] for nr in names_rough]
+    even_better = [b.split('and ') for b in flatten(flatten(better))]
+    # take care of 'reviewed by', strip the command summary, and return list of
+    # unique contributors
+    result = set(flatten([eb.split('; reviewed by ') for eb in flatten(even_better) if eb]))
+
+    return result
+
+
+def unicornify(contributors):
+    """
+    turn contributor names into hashes for unicornify
+    :param contributors: str
+    :return: str
+    """
+    return int(hashlib.md5(contributors.encode('utf-8')).hexdigest(), 16)
+
+
+def compose_json(contributor):
+    return {"name" : contributor,
+            "avatar_url" : 'https://unicornify.pictures/avatar/' + str(unicornify(contributor)) + '?s=128',
+            "contributions": ["translation"]}
+
+
+def write_json(contributors, path='./'):
+    p = Path(path + '.all-contributorsrc')
+    # map of known contributors logins
+    mapping = Path(path + '.allcontrib_map.json')
+    data = json.load(open(p))
+    maps = json.load(open(mapping))
+    names = [i['name'] for i in data['contributors']]
+    known = [i['name'] for i in maps['known_contributors']]
+    for contributor in contributors:
+        if contributor not in names and contributor not in known:
+            newone = compose_json(contributor)
+            data['contributors'].append(newone)
+
+    with open(p, 'w') as outfile:
+        json.dump(data, outfile, indent=2, ensure_ascii=False)
+
+
+if __name__ == '__main__':
+    translators = get_ack()
+    write_json(translators)


### PR DESCRIPTION
This adds a small, hacky script that uses the `git grep` call @yarikoptic pasted in https://github.com/con/open-brain-consent/issues/71#issuecomment-650605678 to extract the names of non-Github based contributors, generates a [unicorn identicon](https://unicornify.pictures/) for them based on a hash of their name, and adds them to `.all-contributorsrc` if they are not included yet.

I executed the script using `datalad run`, so *in principle* rerunning a38cc98 should always keep the contributors list of non-GH contributors up to date.

This is somewhat untested, and my script is hacky - I appreciate tips on how to write it better :)
For the contributors to show up in the README, one bot invocation is required after merging this (we could add me for code or tool :wink:), but the contributor count and display should update automatically together with the bot invocation.

TODO: for anyone added without github usernames there is no way to get their email and the like. https://github.com/con/allcontributors-zenodo/ could thus only pull out the names of the contributors for this. Is this something we could in any way improve upon?