### PR TITLE
Add extra text to DUA

### DIFF
--- a/docs/source/gdpr/data_user_agreement.rst
+++ b/docs/source/gdpr/data_user_agreement.rst
@@ -30,18 +30,20 @@ English
 Data user agreement for accessing identifiable human data
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-**Version:** OBC-GDPR-DUA 1.0.0
+**Version:** OBC-GDPR-DUA 1.0.1
 
 I request access to the data collected in the digital repository of the <DEPARTMENT>, part of the <INSTITUTION>, established at <CITY>, <COUNTRY> (hereinafter referred to as the <INSTITUTION SHORTNAME>).
 
 By accepting this agreement, I become the `data controller <https://ec.europa.eu/info/law/law-topic/data-protection/reform/rules-business-and-organisations/obligations/controller-processor/what-data-controller-or-data-processor_en>`_ (as defined under the GDPR) of the data that I have access to, and am responsible that I access these data under the following terms:
 
-1. I will comply with all relevant rules and regulations imposed by my institution and my government.  This agreement never has prevalence over existing general data protection regulations that are applicable in my country.
-2. I will not attempt to establish or retrieve the identity of the study participants. I will not link these data to any other database in a way that could provide identifying information. I shall not request the pseudonymisation key that would link these data to an individual's personal information, nor will I accept any additional information about individual participants under this Data Use Agreement.
-3. I will not redistribute these data or share access to these data with others, unless they have independently applied and been granted access to these data, i.e., signed this Data Use Agreement. This includes individuals in my institution.
-4. [OPTIONAL] When sharing secondary or derivative data (e.g. group statistical maps or templates), I will only do so if they are on a group level, and cannot be deduced information from individual participants.
-5. I will reference the specific source of the accessed data when publicly presenting any results or algorithms that benefited from their use: (a) Papers, book chapters, books, posters, oral presentations, and all other presentations of results derived from the data should acknowledge the origin of the data as follows: "Data were provided (in part) by <Research centre/University Department> <University, Country>”. (b) Authors of publications or presentations using the data should cite relevant publications describing the methods developed and used by the <Research centre/University Department> to acquire and process the data. The specific publications that are appropriate to cite in any given study will depend on what the data were used and for what purposes. When applicable, a list of publications will be included in the collection. (c) Neither the <Research centre/University Department> or <University>, nor the researchers that provide this data will be liable for any results and/or derived data. They shall not be included as an author of publications or presentations without consent.
-6. Failure to abide by these guidelines will result in termination of my privileges to access these data.
+1. I will comply with all relevant rules and regulations imposed by my institution and my government. This agreement never has prevalence over existing general data protection regulations that are applicable in my country.
+2. I acknowledge that these data are provided “as is”, without any warranty of satisfactory quality or fitness for a particular purpose or use, or any other warranty.
+3. I will not attempt to establish or retrieve the identity of the study participants. I will not link these data to any other database in a way that could provide identifying information. I shall not request the pseudonymisation key that would link these data to an individual's personal information, nor will I accept any additional information about individual participants under this Data Use Agreement.
+4. I will not redistribute these data or share access to these data with others, unless they have independently applied and been granted access to these data, i.e., signed this Data Use Agreement. This includes individuals in my institution. 
+5. [OPTIONAL] When sharing secondary or derivative data (e.g. group statistical maps or templates), I will only do so if they are on a group level, and cannot be deduced information from individual participants.
+6. I will make the necessary efforts to store the data at a sufficiently secure location. I will immediately alert the data owners of (re/dis)use that is not authorized by this agreement, including data loss and breach of personally identifiable information.
+7. I will reference the specific source of the accessed data when publicly presenting any results or algorithms that benefited from their use: (a) Papers, book chapters, books, posters, oral presentations, and all other presentations of results derived from the data should acknowledge the origin of the data as follows: "Data were provided (in part) by <Research centre/University Department> <University, Country>”. (b) Authors of publications or presentations using the data should cite relevant publications describing the methods developed and used by the <Research centre/University Department> to acquire and process the data. The specific publications that are appropriate to cite in any given study will depend on what the data were used and for what purposes. When applicable, a list of publications will be included in the collection. (c) Neither the <Research centre/University Department> or <University>, nor the researchers that provide this data will be liable for any results and/or derived data. They shall not be included as an author of publications or presentations without consent.
+8. Failure to abide by these guidelines will result in termination of my privileges to access these data.
 
 
 Translations
@@ -61,3 +63,5 @@ Translations
    i18n/data_user_agreement.nl.rst
    i18n/data_user_agreement.no.rst
    i18n/data_user_agreement.tr.rst
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
closes #63 

Could still be added:
- After termination, the user(s) is/are required to remove (all elements of) the data from their own storage and to make certain that no third parties have access to the data. A notification to the provider(s) is also required.
- <Country's> law applies to this agreement. Disputes will only be submitted to the district court in The Hague, but not before the parties have made an extreme attempt to settle their dispute in another way. of course this may not be feasible for an international template

This last point relates to the lawfulness of the agreement: does law apply to this DUA? Officially, (personal) research data are property of the institution (at least in NL, not sure about other countries) and thus a specific person has to sign such an agreement (usually not researchers themselves). Should there be text about this on the DUA page as well?