### PR TITLE
SCC to transfer personal data to third countries

### DIFF
--- a/docs/source/gdpr/data_user_agreement.rst
+++ b/docs/source/gdpr/data_user_agreement.rst
@@ -5,6 +5,9 @@ Data User Agreement
 
 A DUA does not provide a legal basis to share personal data (the consent does). A DUA allows controlling what happens to the data when it is shared. A DUA can be a legal instrument if the data are shared for further processing with similar purposes as the original research project (it gives a legal basis to the secondary data user).
 
+Before transfering personal data from the European Union to third countries, data importers must also comply with the `standard contractual clauses <http://data.europa.eu/eli/dec_impl/2021/914/oj>`_ (SCC), the DUA by itself is not sufficient.
+
+
 .. _Data User Agreement (DUA):
 
 This template is based on the `Donder’s Institute DUA Version RU-DI-HD-1.0 <https://data.donders.ru.nl/doc/dua/RU-DI-HD-1.0.html?2>`_.


### PR DESCRIPTION
Transfer of personal data to third countries may only take place if data importers comply with the [SCC](http://data.europa.eu/eli/dec_impl/2021/914/oj). The DUA by itself is not sufficient.

Fixes #114.